### PR TITLE
feat: started trying to fix typing of score matching

### DIFF
--- a/coreax/kernels/scalar_valued.py
+++ b/coreax/kernels/scalar_valued.py
@@ -747,7 +747,7 @@ class SteinKernel(UniCompositeKernel):
         :math:`\mathbb{R}^d \to \mathbb{R}^d`
     """
 
-    score_function: Callable[[Shaped[Array, " n d"]], Shaped[Array, " n d"]]
+    score_function: Callable[[Shaped[Array, " d"]], Shaped[Array, " d"]]
 
     @override
     def compute_elementwise(self, x, y):


### PR DESCRIPTION
### Description

In this pull request, the following changes were made:

1. The signature of the `score_function` attribute in the `SteinKernel` class was modified to accept and return vectors instead of matrices for input and output.
2. The typing import statement was updated in the `coreax/score_matching.py` file to include the `Optional` type.
3. An import statement to `_atleast_2d_consistent` was added in the `coreax/score_matching.py` file.
4. The `match` method in the `ScoreMatching` class and its subclasses now take and return vectors instead of matrices for data processing.
5. The data handling in various methods was updated to ensure consistency and dimension matching for input vectors.

These changes ensure consistency with input and output vector dimensions and enhance overall code quality in handling the data more efficiently.

If you have any concerns or questions about these changes, please let me know!

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the typing of score functions to handle single vector inputs instead of matrices and ensure consistent input formatting using `_atleast_2d_consistent`.

### Why are these changes being made?

The changes improve the type safety and clarity of the score function interfaces by focusing on single vector inputs, which aligns with the intended use of these functions. Additionally, using `_atleast_2d_consistent` ensures that input data is consistently formatted, reducing potential errors and improving code maintainability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->